### PR TITLE
docs: replace leftover linter terminology with next version wording

### DIFF
--- a/end-to-end-tests/features/assert_current_version.feature
+++ b/end-to-end-tests/features/assert_current_version.feature
@@ -3,7 +3,7 @@ Feature: The current version argument supplied is asserted to be equal or greate
 
   Scenario Outline: The current version assertion passes with batched together increments.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --current-version is provided as "<current_version>".
     And the argument --calculation-mode is provided as "batch".
@@ -19,7 +19,7 @@ Feature: The current version argument supplied is asserted to be equal or greate
 
   Scenario Outline: The current version assertion fails with batched together increments.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --current-version is provided as "<current_version>".
     And the argument --calculation-mode is provided as "batch".
@@ -34,7 +34,7 @@ Feature: The current version argument supplied is asserted to be equal or greate
 
   Scenario Outline: The current version assertion passes with consecutive increments.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --current-version is provided as "<current_version>".
     Then the current version assertion passes.
@@ -48,7 +48,7 @@ Feature: The current version argument supplied is asserted to be equal or greate
 
   Scenario Outline: The current version assertion fails with consecutive increments.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --current-version is provided as "<current_version>".
     Then the current version assertion fails.

--- a/end-to-end-tests/features/batch_semantic_versioning.feature
+++ b/end-to-end-tests/features/batch_semantic_versioning.feature
@@ -3,7 +3,7 @@ Feature: The increments are batched together and the largest increment determine
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --calculation-mode is provided as "batch".
     Then the returned version should be "<expected_version>".

--- a/end-to-end-tests/features/consecutive_semantic_versioning.feature
+++ b/end-to-end-tests/features/consecutive_semantic_versioning.feature
@@ -3,7 +3,7 @@ Feature: The increments are applied consecutively to calculate the next semantic
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
 

--- a/end-to-end-tests/features/from_commit_hash.feature
+++ b/end-to-end-tests/features/from_commit_hash.feature
@@ -3,7 +3,7 @@ Feature: A Git commit hash can be provided as an argument to indicate where to s
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --current-version is provided as "<current_version>".
     Then the current version assertion passes.
@@ -17,7 +17,7 @@ Feature: A Git commit hash can be provided as an argument to indicate where to s
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --current-version is provided as "<current_version>".
     Then the current version assertion fails.
@@ -31,7 +31,7 @@ Feature: A Git commit hash can be provided as an argument to indicate where to s
 
   Scenario Outline: When you provide an invalid commit hash a relevant error message is returned.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then their is a could not find commit hash "<commit_hash>" error.
 

--- a/end-to-end-tests/features/from_reference.feature
+++ b/end-to-end-tests/features/from_reference.feature
@@ -3,7 +3,7 @@ Feature: A Git reference can be provided as an argument to indicate where to sta
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<reference>".
+    When calculating from the "<reference>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
 
@@ -15,15 +15,15 @@ Feature: A Git reference can be provided as an argument to indicate where to sta
 
   Scenario Outline: You can also provide the long name and partial names not just the short name.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<full_reference>".
+    When calculating from the "<full_reference>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
     Given the arguments are reset.
-    When linting from the "<partial_reference>".
+    When calculating from the "<partial_reference>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
     Given the arguments are reset.
-    When linting from the "<short_reference>".
+    When calculating from the "<short_reference>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
 
@@ -35,7 +35,7 @@ Feature: A Git reference can be provided as an argument to indicate where to sta
 
   Scenario Outline: When you provide an invalid reference a relevant error message is returned.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<reference>".
+    When calculating from the "<reference>".
     And the argument --from-version is provided as "<from_version>".
     Then their is a could not find reference "<reference>" error.
 

--- a/end-to-end-tests/features/from_shortened_commit_hash.feature
+++ b/end-to-end-tests/features/from_shortened_commit_hash.feature
@@ -3,12 +3,12 @@ Feature: A shortened Git commit hash can be provided as an argument to indicate 
 
   Scenario Outline: A shortened and full Git commit hash can be used interchangeably.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --calculation-mode is provided as "batch".
     Then the returned version should be "<expected_version>".
     Given the arguments are reset.
-    When linting from the "<shortened_commit_hash>".
+    When calculating from the "<shortened_commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --calculation-mode is provided as "batch".
     Then the returned version should be "<expected_version>".
@@ -23,11 +23,11 @@ Feature: A shortened Git commit hash can be provided as an argument to indicate 
 
   Scenario Outline: A shortened and full Git commit hash can be used interchangeably.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
     Given the arguments are reset.
-    When linting from the "<shortened_commit_hash>".
+    When calculating from the "<shortened_commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
 
@@ -41,7 +41,7 @@ Feature: A shortened Git commit hash can be provided as an argument to indicate 
 
   Scenario Outline: The shortened Git commit hash has no matches, so an error is returned.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<shortened_commit_hash>".
+    When calculating from the "<shortened_commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then their is a could not find shortened commit hash "<shortened_commit_hash>" error.
 
@@ -54,7 +54,7 @@ Feature: A shortened Git commit hash can be provided as an argument to indicate 
 
   Scenario Outline: The shortened Git commit hash is ambiguous as multiple commit hashes match it, so an error is returned.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<shortened_commit_hash>".
+    When calculating from the "<shortened_commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then their is a ambiguous shortened commit hash "<shortened_commit_hash>" error.
 

--- a/end-to-end-tests/features/from_stdin.feature
+++ b/end-to-end-tests/features/from_stdin.feature
@@ -4,7 +4,7 @@ Feature: A commit message can be provided by standard input rather than from a r
   Scenario Outline:
     Given the context and environment are reset.
     When the argument --from-version is provided as "<from_version>".
-    When linting the "<commit_message>".
+    When calculating the "<commit_message>".
     Then the returned version should be "<expected_version>".
 
 

--- a/end-to-end-tests/features/git_environment_variables.feature
+++ b/end-to-end-tests/features/git_environment_variables.feature
@@ -3,7 +3,7 @@ Feature: Git environment variables are respected and used instead of using the c
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --current-version is provided as "<current_version>".
     Then the current version assertion passes.
@@ -19,7 +19,7 @@ Feature: Git environment variables are respected and used instead of using the c
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --current-version is provided as "<current_version>".
     Then the current version assertion fails.
@@ -35,7 +35,7 @@ Feature: Git environment variables are respected and used instead of using the c
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<reference>".
+    When calculating from the "<reference>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
     Given the GIT_DIR environment variable is set to the cloned repository.
@@ -49,7 +49,7 @@ Feature: Git environment variables are respected and used instead of using the c
 
   Scenario Outline: You can also provide the long name and partial names not just the short name.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<reference>".
+    When calculating from the "<reference>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
     Given the GIT_DIR environment variable is set to the cloned repository.

--- a/end-to-end-tests/features/history_mode.feature
+++ b/end-to-end-tests/features/history_mode.feature
@@ -3,7 +3,7 @@ Feature: Specifies how commits are parsed, acceptable values are 'first' to pars
 
   Scenario Outline: All the parents of merge commit's are parsed for their Git commit messages.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<default_expected_version>".
     When the argument --history-mode is provided as "all".
@@ -17,7 +17,7 @@ Feature: Specifies how commits are parsed, acceptable values are 'first' to pars
 
   Scenario Outline: Only the first parent of merge commit's are parsed for their Git commit messages.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --history-mode is provided as "first".
     Then the returned version should be "<expected_version>".
@@ -30,7 +30,7 @@ Feature: Specifies how commits are parsed, acceptable values are 'first' to pars
 
   Scenario Outline: Only the first parent of merge commit's are parsed for their Git commit messages, by default.
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
 

--- a/end-to-end-tests/features/monorepo.feature
+++ b/end-to-end-tests/features/monorepo.feature
@@ -3,11 +3,11 @@ Feature: The next semantic version is calculated only from commits altering file
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
     Given the arguments are reset.
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --monorepo is provided as "<monorepo>".
     Then the returned version should be "<monorepo_expected_version>".
@@ -20,11 +20,11 @@ Feature: The next semantic version is calculated only from commits altering file
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
     Given the arguments are reset.
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     And the argument --monorepo is provided as "<monorepo_1>".
     And the argument --monorepo is provided as "<monorepo_2>".

--- a/end-to-end-tests/features/pre_major_release.feature
+++ b/end-to-end-tests/features/pre_major_release.feature
@@ -3,12 +3,12 @@ Feature: Breaking changes for pre-major release semantic versions only increment
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<post_major_release_from_version>".
     And the argument --calculation-mode is provided as "batch".
     Then the returned version should be "<post_major_release_expected_version>".
     Given the arguments are reset.
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<pre_major_release_from_version>".
     And the argument --calculation-mode is provided as "batch".
     Then the returned version should be "<pre_major_release_expected_version>".
@@ -21,11 +21,11 @@ Feature: Breaking changes for pre-major release semantic versions only increment
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<post_major_release_from_version>".
     Then the returned version should be "<post_major_release_expected_version>".
     Given the arguments are reset.
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<pre_major_release_from_version>".
     Then the returned version should be "<pre_major_release_expected_version>".
 

--- a/end-to-end-tests/features/steps/when.py
+++ b/end-to-end-tests/features/steps/when.py
@@ -2,18 +2,17 @@ import tempfile
 from behave import when
 
 
-@when('linting the "{commit_message}".')
-def set_linting_the(context, commit_message):
+@when('calculating the "{commit_message}".')
+def set_calculating_the(context, commit_message):
     context.commit_message = commit_message.strip()
     context.pre_command = f"echo -e {context.commit_message} | "
     context.from_ref = " \"-\""
     # Testing we can use stdin when not in a Git repository.
-    # https://gitlab.com/DeveloperC/conventional_commits_linter/-/issues/3
     context.remote_repository_cache = tempfile.mkdtemp()
 
 
-@when('linting from the "{git}".')
-def set_linting_from_the(context, git):
+@when('calculating from the "{git}".')
+def set_calculating_from_the(context, git):
     context.from_ref = f" \"{git}\""
 
 

--- a/end-to-end-tests/features/v_prefix_ignored.feature
+++ b/end-to-end-tests/features/v_prefix_ignored.feature
@@ -3,7 +3,7 @@ Feature: The semantic version if prefixed with a v is supported and can still be
 
   Scenario Outline:
     Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
-    When linting from the "<commit_hash>".
+    When calculating from the "<commit_hash>".
     And the argument --from-version is provided as "<from_version>".
     Then the returned version should be "<expected_version>".
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -48,7 +48,7 @@ pub(crate) struct Arguments {
     pub(crate) verbose: bool,
 
     #[arg(
-        help = "The Git reference from where to start taking the range of commits from till HEAD to lint. The range is inclusive of HEAD and exclusive of the provided reference. '-' indicates to read the standard input and lint the input as a Git commit message."
+        help = "The Git reference from where to start taking the range of commits from till HEAD to calculate the next semantic version from. The range is inclusive of HEAD and exclusive of the provided reference. '-' indicates to read the standard input and parse the input as a Git commit message."
     )]
     pub(crate) from: String,
 }


### PR DESCRIPTION
The CLI help text and end-to-end feature steps were carried over from
the sibling conventional_commits_linter project and described the tool
as "linting" commits, which contradicts the project's own "Not A
Linter" positioning. Reword them to describe calculating.