### PR TITLE
refactor: extern crate log with per-module use imports

### DIFF
--- a/src/commits/commit/mod.rs
+++ b/src/commits/commit/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use log::{debug, trace};
 use regex::Regex;
 
 const OPTIONAL_PRECEDING_WHITESPACE: &str = "^([[:space:]])*";

--- a/src/commits/filters/mod.rs
+++ b/src/commits/filters/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use git2::{Repository, TreeWalkMode, TreeWalkResult};
+use log::{debug, warn};
 
 pub(super) struct Filters {
     commits_must_effect: Vec<String>,

--- a/src/commits/mod.rs
+++ b/src/commits/mod.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 
 use anyhow::{bail, Context, Result};
 use git2::{Oid, Repository, Revwalk};
+use log::{debug, info};
 use semver::{BuildMetadata, Prerelease, Version};
 
 use crate::calculation_mode::CalculationMode;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,12 @@
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
-extern crate log;
-extern crate pretty_env_logger;
 
 use std::io::{stdin, Read};
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use git2::Repository;
+use log::{debug, error, info};
 
 use crate::cli::Arguments;
 use crate::commits::Commits;


### PR DESCRIPTION
Drop the edition-2015 `#[macro_use] extern crate log;` from main.rs in
favour of scoped `use log::{...}` imports that bring only the macros each
module actually uses into scope:

- main.rs: debug, error, info
- commits/mod.rs: debug, info
- commits/commit/mod.rs: debug, trace
- commits/filters/mod.rs: debug, warn