### PR TITLE
refactor: anyhow context instead of unwrap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,9 @@ fn main() {
 fn run(arguments: Arguments) -> Result<()> {
     let commits = if arguments.from == "-" {
         let mut commit_message = String::new();
-        stdin().read_to_string(&mut commit_message).unwrap();
+        stdin()
+            .read_to_string(&mut commit_message)
+            .context("Unable to read the commit message from standard input.")?;
 
         Ok(Commits::from_commit_message(commit_message))
     } else {


### PR DESCRIPTION
Replace the .unwrap() on stdin read_to_string with .context()? so a
stdin read failure (e.g. non-UTF-8 or a broken pipe) routes through the
clean error! → exit-code-1 path in main.