### PR TITLE
refactor: use edition 2024 expr matcher in filter test macros

### DIFF
--- a/src/commits/filters/tests/mod.rs
+++ b/src/commits/filters/tests/mod.rs
@@ -3,7 +3,7 @@ use rstest::rstest;
 use super::*;
 
 macro_rules! filters {
-    ($filters:expr_2021) => {
+    ($filters:expr) => {
         Filters {
             commits_must_effect: $filters.iter().map(|filters| filters.to_string()).collect(),
         }
@@ -11,7 +11,7 @@ macro_rules! filters {
 }
 
 macro_rules! files {
-    ($files:expr_2021) => {
+    ($files:expr) => {
         $files.iter().map(|file| file.to_string()).collect()
     };
 }


### PR DESCRIPTION
Replace the migration-pinned expr_2021 fragment specifiers with plain
expr now that the crate targets edition 2024.