### PR TITLE
docs: fix duplicated word in --monorepo help text

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,7 +9,7 @@ pub use crate::history_mode::HistoryMode;
 pub(crate) struct Arguments {
     #[arg(
         long,
-        help = "The the next semantic version is calculated only from commits altering files which match any of these provided regexes, enabling usage within monorepos."
+        help = "The next semantic version is calculated only from commits altering files which match any of these provided regexes, enabling usage within monorepos."
     )]
     pub(crate) monorepo: Vec<String>,
 


### PR DESCRIPTION
The help text for the --monorepo argument began with "The the next
semantic version..." Remove the duplicated "The" so the wording matches
the corresponding end-to-end feature description.