### PR TITLE
refactor: avoid unwrap on non-UTF-8 reference name

### DIFF
--- a/src/commits/mod.rs
+++ b/src/commits/mod.rs
@@ -186,7 +186,7 @@ fn get_reference_oid(repository: &Repository, matching: &str) -> Result<Oid> {
     debug!(
         "Matched {:?} to the reference {:?}.",
         matching,
-        reference.name().unwrap()
+        reference.name().unwrap_or("<non-utf8>")
     );
     let commit = reference.peel_to_commit()?;
     Ok(commit.id())


### PR DESCRIPTION
`Reference::name()` returns `None` when the reference name is not valid
UTF-8, so the `unwrap()` in `get_reference_oid` could panic. The call
sits inside a `debug!` invocation, so it only triggers when debug
logging is enabled.